### PR TITLE
feat: explicitly ensure package manager in `scan_dependencies`

### DIFF
--- a/src/jobs/scan_dependencies.yml
+++ b/src/jobs/scan_dependencies.yml
@@ -6,10 +6,13 @@ executor: core/node
 
 parameters:
   pkg_manager:
-    type: enum
-    enum: ['npm', 'pnpm']
-    default: 'npm'
-    description: Choose Node.js package manager to use.
+    type: string
+    default: $DEFAULT_PKG_MANAGER
+    description: |
+      Choose Node.js package manager to use. Supports npm and pnpm.
+      The package manager must follow the format <name>[@<version|tag>].
+      Omitting the version implies that the npm version is determined by the target Node.js environment,
+      while pnpm will default to the latest version.
   pkg_json_dir:
     type: string
     default: '.'
@@ -25,13 +28,11 @@ parameters:
 
 steps:
   - checkout
-  - core/install_dependencies:
-      pkg_manager: <<parameters.pkg_manager>>
-      pkg_json_dir: <<parameters.pkg_json_dir>>
+  - core/ensure_pkg_manager:
+      ref: <<parameters.pkg_manager>>
   - run:
       name: Scan dependencies
       working_directory: <<parameters.pkg_json_dir>>
       environment:
-        PKG_MANAGER: <<parameters.pkg_manager>>
         SCAN_CMD: <<parameters.scan_command>>
       command: <<include(scripts/scan-dependencies.sh)>>

--- a/src/scripts/scan-dependencies.sh
+++ b/src/scripts/scan-dependencies.sh
@@ -3,10 +3,10 @@
 if [[ -n "$SCAN_CMD" ]]; then
   echo "Running custom scan command: $SCAN_CMD"
   eval "$SCAN_CMD"
-elif [[ "$PKG_MANAGER" == "npm" ]]; then
+elif [[ "$CURRENT_PKG_MANAGER" == "npm" ]]; then
   echo "Running npm audit with high audit level omitting dev dependencies"
   npm audit --audit-level=high --omit=dev
-elif [[ "$PKG_MANAGER" == "pnpm" ]]; then
+elif [[ "$CURRENT_PKG_MANAGER" == "pnpm" ]]; then
   echo "Running pnpm audit with high audit level on prod dependencies"
   pnpm audit --audit-level=high --prod
 fi


### PR DESCRIPTION
Install package manager explicitly using the `core/ensure_pkg_manager` command instead through the `core/install_dependencies` command since actual dependencies are not needed for the audit command, plus this should also benefit the performance.