### PR TITLE
refactor: set `medium` resource class for `gitleaks` executor

### DIFF
--- a/src/executors/gitleaks.yml
+++ b/src/executors/gitleaks.yml
@@ -11,7 +11,7 @@ parameters:
   resource_class:
     type: enum
     enum: ['small', 'medium', 'medium+', 'large', 'xlarge', '2xlarge', '2xlarge+']
-    default: 'large'
+    default: 'medium'
     description: Choose the executor resource class
 
 docker:


### PR DESCRIPTION
Aligns resource classes among executors across orbs.