### PR TITLE
fix: check lockfile before scanning dependencies

### DIFF
--- a/src/jobs/scan_dependencies.yml
+++ b/src/jobs/scan_dependencies.yml
@@ -28,6 +28,10 @@ parameters:
 
 steps:
   - checkout
+  - run:
+      name: Check lockfile
+      working_directory: <<parameters.pkg_json_dir>>
+      command: <<include(scripts/check-lockfile.sh)>>
   - core/ensure_pkg_manager:
       ref: <<parameters.pkg_manager>>
   - run:

--- a/src/scripts/check-lockfile.sh
+++ b/src/scripts/check-lockfile.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ ! -f "package-lock.json" ] && [ ! -f "pnpm-lock.yaml" ]; then
+  echo "Lockfile not found"
+
+  exit 1
+fi


### PR DESCRIPTION
The `scan_dependencies` command will now check for the lockfile at the beginning to ensure everything is in place for dependencies scan.