### PR TITLE
refactor: export git branches

### DIFF
--- a/src/jobs/analyze_code.yml
+++ b/src/jobs/analyze_code.yml
@@ -34,6 +34,11 @@ parameters:
 steps:
   - checkout
   - run:
+      name: Export Git branches
+      environment:
+        BASE_BRANCH_OVERRIDE: <<parameters.base_branch>>
+      command: <<include(scripts/export-git-branches.sh)>>
+  - run:
       name: Analyze code
       working_directory: <<parameters.path>>
       environment:
@@ -41,5 +46,4 @@ steps:
         FULL_SCAN: <<parameters.full_scan>>
         VERBOSE: <<parameters.verbose>>
         RULES: <<parameters.rules>>
-        BASE_BRANCH_OVERRIDE: <<parameters.base_branch>>
       command: <<include(scripts/analyze-code.sh)>>

--- a/src/jobs/detect_secrets_git.yml
+++ b/src/jobs/detect_secrets_git.yml
@@ -33,6 +33,11 @@ parameters:
 steps:
   - checkout
   - run:
+      name: Export Git branches
+      environment:
+        BASE_BRANCH_OVERRIDE: <<parameters.base_branch>>
+      command: <<include(scripts/export-git-branches.sh)>>
+  - run:
       name: Export Gitleaks arguments
       environment:
         CONFIG_FILE: <<parameters.config>>
@@ -43,6 +48,5 @@ steps:
       working_directory: <<parameters.path>>
       environment:
         REPO_PATH: <<parameters.path>>
-        BASE_BRANCH_OVERRIDE: <<parameters.base_branch>>
         BASE_REVISION: <<parameters.base_revision>>
       command: <<include(scripts/detect-secrets-git.sh)>>

--- a/src/scripts/analyze-code.sh
+++ b/src/scripts/analyze-code.sh
@@ -26,25 +26,14 @@ ARGS="$ARGS --config $(join ' --config ' "${RULE_ARRAY[@]}")"
 
 ########### BASELINE COMMIT ###########
 
-BASE_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | cut -c8-)
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-if [[ -n $BASE_BRANCH_OVERRIDE ]]; then
-  BASE_BRANCH=$BASE_BRANCH_OVERRIDE
-fi
-
-if [[ -n $CIRCLE_BRANCH ]]; then
-  CURRENT_BRANCH=$CIRCLE_BRANCH
-fi
-
 BASELINE_COMMIT=""
 
-if [ "$FULL_SCAN" -eq 0 ] && [[ "$BASE_BRANCH" = "$CURRENT_BRANCH" ]]; then
+if [ "$FULL_SCAN" -eq 0 ] && [[ "$GIT_BASE_BRANCH" = "$GIT_CURRENT_BRANCH" ]]; then
   # Usually when changes are merged back into a long-lived branch, e.g. trunk
   BASELINE_COMMIT=$(git rev-parse HEAD~1)
-elif [ "$FULL_SCAN" -eq 0 ] && [[ "$BASE_BRANCH" != "$CURRENT_BRANCH" ]]; then
+elif [ "$FULL_SCAN" -eq 0 ] && [[ "$GIT_BASE_BRANCH" != "$GIT_CURRENT_BRANCH" ]]; then
   # Usually a short-lived branch, in other words a pull request
-  BASELINE_COMMIT="$(git rev-parse "$BASE_BRANCH")"
+  BASELINE_COMMIT="$(git rev-parse "$GIT_BASE_BRANCH")"
 fi
 
 if [[ -n $BASELINE_COMMIT ]]; then

--- a/src/scripts/detect-secrets-git.sh
+++ b/src/scripts/detect-secrets-git.sh
@@ -1,22 +1,11 @@
 #!/bin/bash
 
-BASE_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | cut -c8-)
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-if [[ -n $BASE_BRANCH_OVERRIDE ]]; then
-  BASE_BRANCH=$BASE_BRANCH_OVERRIDE
-fi
-
-if [[ -n $CIRCLE_BRANCH ]]; then
-  CURRENT_BRANCH=$CIRCLE_BRANCH
-fi
-
 echo "Starting the directory scan at path '$REPO_PATH'"
 echo "Using exported Gitleaks args '$GITLEAKS_ARGS'"
-echo "Using '$BASE_BRANCH' as the base branch"
-echo "Using '$CURRENT_BRANCH' as the current branch"
+echo "Using '$GIT_BASE_BRANCH' as the base branch"
+echo "Using '$GIT_CURRENT_BRANCH' as the current branch"
 
-if [[ "$BASE_BRANCH" = "$CURRENT_BRANCH" ]]; then
+if [[ "$GIT_BASE_BRANCH" = "$GIT_CURRENT_BRANCH" ]]; then
   # Usually when changes are merged back into a long-lived branch, e.g. trunk
   echo "The base branch is the current branch"
   LOG_OPTS="$BASE_REVISION^..$CIRCLE_SHA1"
@@ -35,8 +24,8 @@ if [[ "$BASE_BRANCH" = "$CURRENT_BRANCH" ]]; then
 else
   # Usually a short lived branch, that is a pull request
   echo "The base branch is not the current branch"
-  echo "Scanning all the commits in the current branch '$CURRENT_BRANCH'"
-  eval gitleaks "$GITLEAKS_ARGS" --log-opts="$BASE_BRANCH..$CURRENT_BRANCH"
+  echo "Scanning all the commits in the current branch '$GIT_CURRENT_BRANCH'"
+  eval gitleaks "$GITLEAKS_ARGS" --log-opts="$GIT_BASE_BRANCH..$GIT_CURRENT_BRANCH"
 fi
 
 

--- a/src/scripts/export-git-branches.sh
+++ b/src/scripts/export-git-branches.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+BASE_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | cut -c8-)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ -n $BASE_BRANCH_OVERRIDE ]]; then
+  BASE_BRANCH=$BASE_BRANCH_OVERRIDE
+fi
+
+if [[ -n $CIRCLE_BRANCH ]]; then
+  CURRENT_BRANCH=$CIRCLE_BRANCH
+fi
+
+echo "export GIT_BASE_BRANCH='$BASE_BRANCH'" >> "$BASH_ENV"
+echo "export GIT_CURRENT_BRANCH='$CURRENT_BRANCH'" >> "$BASH_ENV"


### PR DESCRIPTION
Extract exporting of base and current Git branches environment variables into the script to allow reuse across different jobs.