### PR TITLE
docs: fix typo in `base_revision` parameter description

### DIFF
--- a/src/jobs/detect_secrets_git.yml
+++ b/src/jobs/detect_secrets_git.yml
@@ -28,7 +28,7 @@ parameters:
     default: ''
     description: >
       The hash of the last scanned commit from the prior build. Usually, pass CircleCI
-      "<<pipeline.git.base revision>>" pipeline parameter.
+      "<<pipeline.git.base_revision>>" pipeline parameter.
 
 steps:
   - checkout


### PR DESCRIPTION
Correctly spell the `pipeline.git.base_revision` stated in the `base_revision` parameter of the `detect_secrets_git` job.