### PR TITLE
feat: remove reporting to file for detecting secrets jobs

### DIFF
--- a/src/scripts/export-gitleaks-args.sh
+++ b/src/scripts/export-gitleaks-args.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-REPORT="--report-format=sarif --report-path=/tmp/gitleaks-report.sarif"
-ARGS="detect --source . --log-level=debug --verbose --redact $REPORT --exit-code=2"
+ARGS="detect --source . --log-level=debug --verbose --redact --exit-code=2"
 
 if [[ -n "$CONFIG_FILE" ]]; then
   ARGS="$ARGS --config=$CONFIG_FILE"


### PR DESCRIPTION
Remove report flags and thus reporting to a file for `detect_secrets_git` and `detect_secrets_dir` jobs. Currently, there is not much use for such outputs, and a more systematic approach to reporting is needed across all jobs in the future.