### PR TITLE
style: ensure only one empty line at EOF

### DIFF
--- a/src/scripts/detect-secrets-git.sh
+++ b/src/scripts/detect-secrets-git.sh
@@ -27,6 +27,3 @@ else
   echo "Scanning all the commits in the current branch '$GIT_CURRENT_BRANCH'"
   eval gitleaks "$GITLEAKS_ARGS" --log-opts="$GIT_BASE_BRANCH..$GIT_CURRENT_BRANCH"
 fi
-
-
-


### PR DESCRIPTION
Remove extra empty lines from the `detect-secrets-git.sh` script.