### PR TITLE
feat: base secret detection on the `detect_secrets` command

### DIFF
--- a/src/commands/detect_secrets.yml
+++ b/src/commands/detect_secrets.yml
@@ -1,0 +1,66 @@
+description: >
+  Scan for secrets inside a directory, or Git repository.
+  The heavy lifting is done by Gitleaks, for details see https://github.com/gitleaks/gitleaks#gitleaks.
+
+parameters:
+  source:
+    type: string
+    default: '.'
+    description: The path to the source for the scanning.
+  mode:
+    type: enum
+    enum: ['dir', 'git']
+    default: git
+    description: The scan mode describes the source path - directory or Git repository.
+  config:
+    type: string
+    default: ''
+    description: >
+      The path to the Gitleaks config file. By default, it tries to load "<<parameters.path>>/.gitleaks.toml".
+  baseline_report:
+    type: string
+    default: ''
+    description: The path to the baseline report, i.e. issues that can be ignored.
+  base_branch:
+    type: string
+    default: ''
+    description: >
+      The name of the base branch for this scan. Commonly a long-lived branch, e.g. "main" or "master".
+  base_revision:
+    type: string
+    default: ''
+    description: >
+      The hash of the last scanned commit from the prior build. Usually, pass CircleCI
+      "<<pipeline.git.base_revision>>" pipeline parameter.
+
+steps:
+  - run:
+      name: Export Gitleaks arguments
+      environment:
+        PARAM_STR_CONFIG: <<parameters.config>>
+        PARAM_STR_BASELINE_REPORT: <<parameters.baseline_report>>
+      command: <<include(scripts/export-gitleaks-args.sh)>>
+  - when:
+      condition:
+        equal: [git, <<parameters.mode>>]
+      steps:
+        - run:
+            name: Export Git branches
+            environment:
+              BASE_BRANCH_OVERRIDE: <<parameters.base_branch>>
+            command: <<include(scripts/export-git-branches.sh)>>
+        - run:
+            name: Detect secrets inside the Git repository
+            environment:
+              PARAM_STR_SOURCE: <<parameters.source>>
+              PARAM_STR_BASE_REVISION: <<parameters.base_revision>>
+            command: <<include(scripts/detect-secrets-git.sh)>>
+  - when:
+      condition:
+        equal: [dir, <<parameters.mode>>]
+      steps:
+        - run:
+            name: Detect secrets inside the directory
+            environment:
+              PARAM_STR_SOURCE: <<parameters.source>>
+            command: <<include(scripts/detect-secrets-dir.sh)>>

--- a/src/jobs/detect_secrets_dir.yml
+++ b/src/jobs/detect_secrets_dir.yml
@@ -1,11 +1,10 @@
 description: >
-  Detect secrets leak inside a project at the directory level. Under the hood, the "gitleaks detect"
-  command is utilized. For details on usage see https://github.com/gitleaks/gitleaks#usage.
+  Detect secrets leak inside a project at the directory level.
 
 executor: gitleaks
 
 parameters:
-  path:
+  source:
     type: string
     default: '.'
     description: The path to the directory to scan.
@@ -14,22 +13,15 @@ parameters:
     default: ''
     description: >
       The path to the Gitleaks config file. By default, it tries to load "<<parameters.path>>/.gitleaks.toml".
-  baseline:
+  baseline_report:
     type: string
     default: ''
     description: The path to the baseline report, i.e. issues that can be ignored.
 
 steps:
   - checkout
-  - run:
-      name: Export Gitleaks arguments
-      environment:
-        CONFIG_FILE: <<parameters.config>>
-        BASELINE_REPORT: <<parameters.baseline>>
-      command: <<include(scripts/export-gitleaks-args.sh)>>
-  - run:
-      name: Detect secrets inside the directory
-      working_directory: <<parameters.path>>
-      environment:
-        DIR_PATH: <<parameters.path>>
-      command: <<include(scripts/detect-secrets-dir.sh)>>
+  - detect_secrets:
+      source: <<parameters.source>>
+      mode: dir
+      config: <<parameters.config>>
+      baseline_report: <<parameters.baseline_report>>

--- a/src/jobs/detect_secrets_git.yml
+++ b/src/jobs/detect_secrets_git.yml
@@ -1,11 +1,10 @@
 description: >
-  Detect secrets leak inside a project at the repository level. Under the hood, the "gitleaks detect"
-  command is utilized. For details on usage see https://github.com/gitleaks/gitleaks#usage.
+  Detect secrets leak inside a project at the repository level.
 
 executor: gitleaks
 
 parameters:
-  path:
+  source:
     type: string
     default: '.'
     description: The path to the root of the Git repository to scan.
@@ -14,7 +13,7 @@ parameters:
     default: ''
     description: >
       The path to the Gitleaks config file. By default, it tries to load "<<parameters.path>>/.gitleaks.toml".
-  baseline:
+  baseline_report:
     type: string
     default: ''
     description: The path to the baseline report, i.e. issues that can be ignored.
@@ -32,21 +31,10 @@ parameters:
 
 steps:
   - checkout
-  - run:
-      name: Export Git branches
-      environment:
-        BASE_BRANCH_OVERRIDE: <<parameters.base_branch>>
-      command: <<include(scripts/export-git-branches.sh)>>
-  - run:
-      name: Export Gitleaks arguments
-      environment:
-        CONFIG_FILE: <<parameters.config>>
-        BASELINE_REPORT: <<parameters.baseline>>
-      command: <<include(scripts/export-gitleaks-args.sh)>>
-  - run:
-      name: Detect secrets inside the Git repository
-      working_directory: <<parameters.path>>
-      environment:
-        REPO_PATH: <<parameters.path>>
-        BASE_REVISION: <<parameters.base_revision>>
-      command: <<include(scripts/detect-secrets-git.sh)>>
+  - detect_secrets:
+      source: <<parameters.source>>
+      mode: git
+      config: <<parameters.config>>
+      baseline_report: <<parameters.baseline_report>>
+      base_branch: <<parameters.base_branch>>
+      base_revision: <<parameters.base_revision>>

--- a/src/scripts/detect-secrets-dir.sh
+++ b/src/scripts/detect-secrets-dir.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-echo "Starting the directory scan at path '$DIR_PATH'"
+echo "Starting the directory scan at path '$PARAM_STR_SOURCE'"
 echo "Using exported Gitleaks args '$GITLEAKS_ARGS'"
-eval gitleaks "$GITLEAKS_ARGS" --no-git
+
+eval gitleaks dir "$GITLEAKS_ARGS" "$PARAM_STR_SOURCE"

--- a/src/scripts/detect-secrets-git.sh
+++ b/src/scripts/detect-secrets-git.sh
@@ -1,29 +1,43 @@
 #!/bin/bash
 
-echo "Starting the repository scan at path '$REPO_PATH'"
+EVAL_GITLEAKS_ARGS=$(eval echo "${GITLEAKS_ARGS}")
+
+echo "Starting the repository scan at path '$PARAM_STR_SOURCE'"
 echo "Using exported Gitleaks args '$GITLEAKS_ARGS'"
 echo "Using '$GIT_BASE_BRANCH' as the base branch"
 echo "Using '$GIT_CURRENT_BRANCH' as the current branch"
 
 if [[ "$GIT_BASE_BRANCH" = "$GIT_CURRENT_BRANCH" ]]; then
   # Usually when changes are merged back into a long-lived branch, e.g. trunk
-  echo "The base branch is the current branch"
-  LOG_OPTS="$BASE_REVISION^..$CIRCLE_SHA1"
+  LOG_OPTS="$PARAM_STR_BASE_REVISION^..$CIRCLE_SHA1"
 
-  if [[ -z "$BASE_REVISION" ]] || ! git cat-file -e "$BASE_REVISION"; then
+  echo "The base branch is the current branch"
+
+  if [[ -z "$PARAM_STR_BASE_REVISION" ]] || ! git cat-file -e "$PARAM_STR_BASE_REVISION"; then
+    LOG_OPTS="HEAD~1^..$CIRCLE_SHA1"
+
     echo "The base revision is empty or invalid"
     echo "Using HEAD~1 as the base revision"
-    LOG_OPTS="HEAD~1^..$CIRCLE_SHA1"
-  elif [[ "$BASE_REVISION" == "$CIRCLE_SHA1" ]]; then
+
+  elif [[ "$PARAM_STR_BASE_REVISION" == "$CIRCLE_SHA1" ]]; then
+    LOG_OPTS=-1
+
     echo "The base revision is the current revision"
     echo "Scanning only last commit"
-    LOG_OPTS=-1
+
   fi
 
-  eval gitleaks "$GITLEAKS_ARGS" --log-opts="$LOG_OPTS"
+  EVAL_GITLEAKS_ARGS="$GITLEAKS_ARGS --log-opts=$LOG_OPTS"
+
 else
   # Usually a short lived branch, that is a pull request
   echo "The base branch is not the current branch"
   echo "Scanning all the commits in the current branch '$GIT_CURRENT_BRANCH'"
-  eval gitleaks "$GITLEAKS_ARGS" --log-opts="$GIT_BASE_BRANCH..$GIT_CURRENT_BRANCH"
+
+  EVAL_GITLEAKS_ARGS="$GITLEAKS_ARGS --log-opts=$GIT_BASE_BRANCH..$GIT_CURRENT_BRANCH"
+
 fi
+
+set -x
+eval gitleaks git "$EVAL_GITLEAKS_ARGS" "$PARAM_STR_SOURCE"
+set +x

--- a/src/scripts/export-gitleaks-args.sh
+++ b/src/scripts/export-gitleaks-args.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-ARGS="detect --source . --log-level=debug --verbose --redact --exit-code=2"
+ARGS="--log-level=debug --verbose --redact --exit-code=2"
 
-if [[ -n "$CONFIG_FILE" ]]; then
-  ARGS="$ARGS --config=$CONFIG_FILE"
+if [[ -n "$PARAM_STR_CONFIG_FILE" ]]; then
+  ARGS="$ARGS --config=$PARAM_STR_CONFIG_FILE"
 fi
 
-if [[ -n "$BASELINE_REPORT" ]]; then
-  ARGS="$ARGS --baseline-path=$BASELINE_REPORT"
+if [[ -n "$PARAM_STR_BASELINE_REPORT" ]]; then
+  ARGS="$ARGS --baseline-path=$PARAM_STR_BASELINE_REPORT"
 fi
 
 echo "export GITLEAKS_ARGS='$ARGS'" >> "$BASH_ENV"


### PR DESCRIPTION
Introduce the `detect_secrets` command as the main entry point for secret scanning and refactor jobs to utilize the command. 
Replace the deprecated gitleaks `detect` with the `git` and `dir` commands.