### PR TITLE
feat: base the code analysis on the `analyze_code` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -57,13 +57,11 @@ workflows:
           name: detect_secrets_git_no_revision
           base_branch: <<pipeline.git.branch>>
           filters: *filters
-      - security/analyze_code:
+      - security/analyze_code_diff:
           name: analyze_code_diff
-          path: ~/project/sample
           filters: *filters
-      - security/analyze_code:
+      - security/analyze_code_full:
           name: analyze_code_full
-          full_scan: true
           rules: p/cwe-top-25
           filters: *filters
       - orb-tools/pack:

--- a/src/commands/analyze_code.yml
+++ b/src/commands/analyze_code.yml
@@ -2,18 +2,12 @@ description: >
   Run static analysis, or SAST, to find vulnerabilities in the codebase. Utilizes the Semgrep "scan"
   command to do the analysis. For details on usage see https://semgrep.dev/docs/cli-reference.
 
-executor: semgrep
-
 parameters:
-  path:
-    type: string
-    default: '.'
-    description: The path to the directory to scan.
   full_scan:
     type: boolean
     default: false
     description: >
-      The flag indicating whether to scan the full directory vs just files changed from the last commit,
+      The flag indicating whether to scan the entire codebase vs just files changed from the last commit,
       or the whole branch if it is a short-lived branch, i.e. pull request.
   verbose:
     type: boolean
@@ -21,7 +15,7 @@ parameters:
     description: The flag indicates whether to show more details about rules, files, etc.
   rules:
     type: string
-    default: p/default p/owasp-top-ten p/r2c-security-audit p/eslint
+    default: p/default p/owasp-top-ten p/r2c-security-audit p/cwe-top-25 p/eslint
     description: >
       The space-separated list of Semgrep rules, e.g. YAML configuration file, URL of the configuration
       file, or Semgrep registry entry name.
@@ -32,18 +26,18 @@ parameters:
       The name of the base branch for this scan. Commonly a long-lived branch, e.g. "main" or "master".
 
 steps:
-  - checkout
+  - unless:
+      condition: <<parameters.full_scan>>
+      steps:
+        - run:
+            name: Export Git branches
+            environment:
+              BASE_BRANCH_OVERRIDE: <<parameters.base_branch>>
+            command: <<include(scripts/export-git-branches.sh)>>
   - run:
-      name: Export Git branches
+      name: Analyze code <<#parameters.full_scan>>full<</parameters.full_scan>><<^parameters.full_scan>>diff<</parameters.full_scan>>
       environment:
-        BASE_BRANCH_OVERRIDE: <<parameters.base_branch>>
-      command: <<include(scripts/export-git-branches.sh)>>
-  - run:
-      name: Analyze code
-      working_directory: <<parameters.path>>
-      environment:
-        DIR_PATH: <<parameters.path>>
-        FULL_SCAN: <<parameters.full_scan>>
-        VERBOSE: <<parameters.verbose>>
-        RULES: <<parameters.rules>>
+        PARAM_BOOL_FULL_SCAN: <<parameters.full_scan>>
+        PARAM_BOOL_VERBOSE: <<parameters.verbose>>
+        PARAM_STR_RULES: <<parameters.rules>>
       command: <<include(scripts/analyze-code.sh)>>

--- a/src/jobs/analyze_code_diff.yml
+++ b/src/jobs/analyze_code_diff.yml
@@ -1,0 +1,28 @@
+description: >
+  Run a diff-aware scan on the codebase and report findings.
+
+executor: semgrep
+
+parameters:
+  verbose:
+    type: boolean
+    default: false
+    description: The flag indicates whether to show more details about rules, files, etc.
+  rules:
+    type: string
+    default: p/default p/owasp-top-ten p/r2c-security-audit p/eslint
+    description: >
+      The space-separated list of Semgrep rules, e.g. YAML configuration file, URL of the configuration
+      file, or Semgrep registry entry name.
+  base_branch:
+    type: string
+    default: ''
+    description: >
+      The name of the base branch for this scan. Commonly a long-lived branch, e.g. "main" or "master".
+
+steps:
+  - checkout
+  - analyze_code:
+      verbose: <<parameters.verbose>>
+      rules: <<parameters.rules>>
+      base_branch: <<parameters.base_branch>>

--- a/src/jobs/analyze_code_full.yml
+++ b/src/jobs/analyze_code_full.yml
@@ -1,0 +1,23 @@
+description: >
+  Run a full scan on the codebase and report findings.
+
+executor: semgrep
+
+parameters:
+  verbose:
+    type: boolean
+    default: false
+    description: The flag indicates whether to show more details about rules, files, etc.
+  rules:
+    type: string
+    default: p/default p/owasp-top-ten p/r2c-security-audit p/eslint
+    description: >
+      The space-separated list of Semgrep rules, e.g. YAML configuration file, URL of the configuration
+      file, or Semgrep registry entry name.
+
+steps:
+  - checkout
+  - analyze_code:
+      full_scan: true
+      verbose: <<parameters.verbose>>
+      rules: <<parameters.rules>>


### PR DESCRIPTION
Introduce the `analyze_code` command as the main entry point for the static code analysis.
Add separate jobs for diff and full scanning, `analyze_code_diff` and `analyze_code_full`.
Remove the `path` parameter to avoid confusion and enforce the scan to run at the root level.