### PR TITLE
docs: update the `sast` example

### DIFF
--- a/src/examples/sast.yml
+++ b/src/examples/sast.yml
@@ -1,9 +1,8 @@
 description: |
-  The "analyze_code" job runs a static analysis tool to scan the codebase for vulnerabilities.
-  By default, a diff-aware scanning is performed meaning only file changes in the last commit
-  are scanned, or files scoped to the pull request if a short-lived branch is in question.
-  There is an option to scan all files inside a repository, change a base branch,
-  and enforce a different set of scan rules.
+  The "analyze_code_diff" job runs a static analysis tool to scan the codebase for vulnerabilities.
+  A diff-aware scanning is performed meaning only file changes in the last commit are scanned,
+  or files scoped to the pull request if a short-lived branch is in question.
+  There is an option to change a base branch and enforce a different set of scan rules.
 
 usage:
   version: 2.1
@@ -12,7 +11,6 @@ usage:
   workflows:
     test_codebase:
       jobs:
-        - security/analyze_code:
-            path: ~/workspace
-            full_scan: true
+        - security/analyze_code_diff:
+            rules: p/comment p/secure-defaults
             base_branch: prod


### PR DESCRIPTION
Use the `analyze_code_diff` job to reflect changes made to static code analysis.