### PR TITLE
feat: remove the source pathfrom the `detect_secrest_git` job

### DIFF
--- a/src/jobs/detect_secrets_git.yml
+++ b/src/jobs/detect_secrets_git.yml
@@ -4,10 +4,6 @@ description: >
 executor: gitleaks
 
 parameters:
-  source:
-    type: string
-    default: '.'
-    description: The path to the root of the Git repository to scan.
   config:
     type: string
     default: ''
@@ -32,7 +28,6 @@ parameters:
 steps:
   - checkout
   - detect_secrets:
-      source: <<parameters.source>>
       mode: git
       config: <<parameters.config>>
       baseline_report: <<parameters.baseline_report>>


### PR DESCRIPTION
To avoid confusion and enforce detection at the root level.