### PR TITLE
refactor: rename base branch param to env assignment

### DIFF
--- a/src/commands/analyze_code.yml
+++ b/src/commands/analyze_code.yml
@@ -32,7 +32,7 @@ steps:
         - run:
             name: Export Git branches
             environment:
-              BASE_BRANCH_OVERRIDE: <<parameters.base_branch>>
+              PARAM_STR_BASE_BRANCH: <<parameters.base_branch>>
             command: <<include(scripts/export-git-branches.sh)>>
   - run:
       name: Analyze code <<#parameters.full_scan>>full<</parameters.full_scan>><<^parameters.full_scan>>diff<</parameters.full_scan>>

--- a/src/commands/detect_secrets.yml
+++ b/src/commands/detect_secrets.yml
@@ -47,7 +47,7 @@ steps:
         - run:
             name: Export Git branches
             environment:
-              BASE_BRANCH_OVERRIDE: <<parameters.base_branch>>
+              PARAM_STR_BASE_BRANCH: <<parameters.base_branch>>
             command: <<include(scripts/export-git-branches.sh)>>
         - run:
             name: Detect secrets inside the Git repository

--- a/src/scripts/export-git-branches.sh
+++ b/src/scripts/export-git-branches.sh
@@ -3,8 +3,8 @@
 BASE_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | cut -c8-)
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if [[ -n $BASE_BRANCH_OVERRIDE ]]; then
-  BASE_BRANCH=$BASE_BRANCH_OVERRIDE
+if [[ -n $PARAM_STR_BASE_BRANCH ]]; then
+  BASE_BRANCH=$PARAM_STR_BASE_BRANCH
 fi
 
 if [[ -n $CIRCLE_BRANCH ]]; then


### PR DESCRIPTION
Use the new name, `PARAM_STR_BASE_BRANCH`, for the environment variable that exports the `base_branch` parameter. This ensures better readability and makes the origin clear.