### PR TITLE
feat: replace the `scan_dependencies` job with the command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@12.0
+  core: studion/core@1.0.0
   security: {}
 
 filters: &filters
@@ -13,21 +14,23 @@ release-filters: &release-filters
   tags:
     only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
-workflows:
-  test-deploy:
-    jobs:
+jobs:
+  scan_dependencies_prod_npm:
+    executor: core/node
+    steps:
       - security/scan_dependencies:
-          name: scan_dependencies_npm
           pkg_manager: npm
           pkg_json_dir: ~/project/sample
-          filters: *filters
+  scan_dependencies_prod_pnpm:
+    executor: core/node
+    steps:
       - security/scan_dependencies:
-          name: scan_dependencies_pnpm
           pkg_manager: pnpm
           pkg_json_dir: ~/project/sample
-          filters: *filters
+  scan_dependencies_command:
+    executor: core/node
+    steps:
       - security/scan_dependencies:
-          name: scan_dependencies_command
           pkg_manager: npm
           pkg_json_dir: ~/project/sample
           scan_command: |
@@ -35,6 +38,15 @@ workflows:
             if ! npm audit --audit-level=high; then
               echo "Scan found dependencies with high vulnerability level"
             fi
+
+workflows:
+  test-deploy:
+    jobs:
+      - scan_dependencies_prod_npm:
+          filters: *filters
+      - scan_dependencies_prod_pnpm:
+          filters: *filters
+      - scan_dependencies_command:
           filters: *filters
       - security/detect_secrets_dir:
           name: detect_secrets_dir
@@ -72,8 +84,8 @@ workflows:
           pub_type: production
           requires:
             - orb-tools/pack
-            - scan_dependencies_npm
-            - scan_dependencies_pnpm
+            - scan_dependencies_prod_npm
+            - scan_dependencies_prod_pnpm
             - scan_dependencies_command
             - detect_secrets_dir
             - detect_secrets_git_base_revision

--- a/src/commands/scan_dependencies.yml
+++ b/src/commands/scan_dependencies.yml
@@ -1,13 +1,11 @@
 description: >
-  Scan production dependencies for critical and high severity vulnerabilities.
+  By default, scan production dependencies for critical and high severity vulnerabilities.
   Uses the "audit" command of the targeted package manager.
-
-executor: core/node
 
 parameters:
   pkg_manager:
     type: string
-    default: $DEFAULT_PKG_MANAGER
+    default: ${DEFAULT_PKG_MANAGER}
     description: |
       Choose Node.js package manager to use. Supports npm and pnpm.
       The package manager must follow the format <name>[@<version|tag>].
@@ -35,7 +33,7 @@ steps:
   - core/ensure_pkg_manager:
       ref: <<parameters.pkg_manager>>
   - run:
-      name: Scan dependencies
+      name: Scan dependencies <<^parameters.scan_command>>prod<</parameters.scan_command>>
       working_directory: <<parameters.pkg_json_dir>>
       environment:
         SCAN_CMD: <<parameters.scan_command>>

--- a/src/examples/pnpm_scan.yml
+++ b/src/examples/pnpm_scan.yml
@@ -1,5 +1,5 @@
 description: |
-  By default, the "scan_dependencies" job checks for production dependencies
+  By default, the "scan_dependencies" command checks for production dependencies
   with critical and high severity vulnerabilities.
   There is an option to override the scan command, package manager, and root directory.
 
@@ -7,9 +7,14 @@ usage:
   version: 2.1
   orbs:
     security: studion/security@x.y.z
-  workflows:
-    scan_app_dependencies:
-      jobs:
+  jobs:
+    scan_command:
+      executor: core/node
+      steps:
         - security/scan_dependencies:
             pkg_json_dir: ~/app
             scan_command: pnpm audit
+  workflows:
+    scan_app_dependencies:
+      jobs:
+        - scan_command

--- a/src/scripts/scan-dependencies.sh
+++ b/src/scripts/scan-dependencies.sh
@@ -2,11 +2,17 @@
 
 if [[ -n "$SCAN_CMD" ]]; then
   echo "Running custom scan command: $SCAN_CMD"
+
   eval "$SCAN_CMD"
+
 elif [[ "$CURRENT_PKG_MANAGER" == "npm" ]]; then
   echo "Running npm audit with high audit level omitting dev dependencies"
+
   npm audit --audit-level=high --omit=dev
+
 elif [[ "$CURRENT_PKG_MANAGER" == "pnpm" ]]; then
   echo "Running pnpm audit with high audit level on prod dependencies"
+
   pnpm audit --audit-level=high --prod
+
 fi


### PR DESCRIPTION
Replacing the job with the same-named command allows for better usability of dependency scanning.