### PR TITLE
feat: change the source path usage for secrets detection

### DIFF
--- a/src/commands/detect_secrets.yml
+++ b/src/commands/detect_secrets.yml
@@ -6,7 +6,9 @@ parameters:
   source:
     type: string
     default: '.'
-    description: The path to the source for the scanning.
+    description: >
+      The path to the source for the scanning. Defaults to . (working directory).
+      Only utilized in the "dir" mode. The "git" mode will always use the working directory.
   mode:
     type: enum
     enum: ['dir', 'git']
@@ -52,7 +54,6 @@ steps:
         - run:
             name: Detect secrets inside the Git repository
             environment:
-              PARAM_STR_SOURCE: <<parameters.source>>
               PARAM_STR_BASE_REVISION: <<parameters.base_revision>>
             command: <<include(scripts/detect-secrets-git.sh)>>
   - when:
@@ -61,6 +62,5 @@ steps:
       steps:
         - run:
             name: Detect secrets inside the directory
-            environment:
-              PARAM_STR_SOURCE: <<parameters.source>>
+            working_directory: <<parameters.source>>
             command: <<include(scripts/detect-secrets-dir.sh)>>

--- a/src/jobs/detect_secrets_dir.yml
+++ b/src/jobs/detect_secrets_dir.yml
@@ -7,7 +7,7 @@ parameters:
   source:
     type: string
     default: '.'
-    description: The path to the directory to scan.
+    description: The path to the directory to scan. Defaults to . (working directory).
   config:
     type: string
     default: ''

--- a/src/scripts/detect-secrets-dir.sh
+++ b/src/scripts/detect-secrets-dir.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-echo "Starting the directory scan at path '${PARAM_STR_SOURCE}'"
+echo "Starting the directory scan at path '${PWD}'"
 
 set -x
-eval gitleaks dir "${GITLEAKS_ARGS}" "${PARAM_STR_SOURCE}"
+eval \
+  gitleaks \
+  dir \
+  "${GITLEAKS_ARGS}" \
+  .
 set +x

--- a/src/scripts/detect-secrets-git.sh
+++ b/src/scripts/detect-secrets-git.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-EVAL_GITLEAKS_ARGS=$(eval echo "${GITLEAKS_ARGS}")
 LOG_OPTS=""
 
 echo "Using '${GIT_BASE_BRANCH}' as the base branch"
@@ -35,8 +34,11 @@ else
 
 fi
 
-EVAL_GITLEAKS_ARGS="${EVAL_GITLEAKS_ARGS} --log-opts=${LOG_OPTS}"
-
 set -x
-eval gitleaks git "${EVAL_GITLEAKS_ARGS}" "${PARAM_STR_SOURCE}"
+eval \
+  gitleaks \
+  git \
+  "${GITLEAKS_ARGS}" \
+  --log-opts="${LOG_OPTS}" \
+  .
 set +x


### PR DESCRIPTION
- Remove the environment mappings for the source path
- Use the `working_directory` option, to set the source for the dir mode
- Always execute the git mode in the working directory
- Use `PWD` env to log the working directory during execution