### PR TITLE
feat: remove the checkout step from the dependency scanning

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -18,18 +18,21 @@ jobs:
   scan_dependencies_prod_npm:
     executor: core/node
     steps:
+      - checkout
       - security/scan_dependencies:
           pkg_manager: npm
           pkg_json_dir: ~/project/sample
   scan_dependencies_prod_pnpm:
     executor: core/node
     steps:
+      - checkout
       - security/scan_dependencies:
           pkg_manager: pnpm
           pkg_json_dir: ~/project/sample
   scan_dependencies_command:
     executor: core/node
     steps:
+      - checkout
       - security/scan_dependencies:
           pkg_manager: npm
           pkg_json_dir: ~/project/sample

--- a/src/commands/scan_dependencies.yml
+++ b/src/commands/scan_dependencies.yml
@@ -25,7 +25,6 @@ parameters:
       "npm audit --audit-level=high --omit=dev" or "pnpm audit --audit-level high --prod", are unsuitable.
 
 steps:
-  - checkout
   - run:
       name: Check the lockfile
       working_directory: <<parameters.pkg_json_dir>>

--- a/src/examples/pnpm_scan.yml
+++ b/src/examples/pnpm_scan.yml
@@ -11,6 +11,7 @@ usage:
     scan_command:
       executor: core/node
       steps:
+        - checkout
         - security/scan_dependencies:
             pkg_json_dir: ~/app
             scan_command: pnpm audit


### PR DESCRIPTION
The checkout step is removed from the `scan dependencies` command to allow for better reusability.