### PR TITLE
ci: add the `scan_dockerfile` as the requirement for publishing

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -98,6 +98,7 @@ workflows:
             - scan_dependencies_prod_npm
             - scan_dependencies_prod_pnpm
             - scan_dependencies_command
+            - scan_dockerfile
             - detect_secrets_dir
             - detect_secrets_git_base_revision
             - analyze_code_diff


### PR DESCRIPTION
The `scan_dockerfile` test job is added to the list of dependencies for the orb publishing job.