### PR TITLE
docs: add Dockerfiles scanning to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Key features:
 - Detect secret leaks on the changeset or target a directory
 - Run a diff-aware static analysis tool to detect vulnerabilities
 - Opt for a full scan of the codebase when needed
+- Scan Dockerfiles for configuration issues
 
 ## Usage
 


### PR DESCRIPTION
The README points out the option of a Dockerfile misconfiguration scanning.