### PR TITLE
feat: add `install_trivy` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -47,6 +47,18 @@ jobs:
       - checkout
       - security/scan_dockerfile:
           dockerfile_dir: ./sample
+  install_trivy:
+    executor: core/node
+    steps:
+      - security/install_trivy:
+          version: v0.59.1
+      - run:
+          name: Validate installation
+          command: |
+            if ! trivy --version | grep -q "0.59.1"; then
+              echo "Failed to install chosen trivy version"
+              exit 1
+            fi
 
 workflows:
   test-deploy:
@@ -87,6 +99,8 @@ workflows:
           name: analyze_code_full
           rules: p/cwe-top-25
           filters: *filters
+      - install_trivy:
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -103,5 +117,6 @@ workflows:
             - detect_secrets_git_base_revision
             - analyze_code_diff
             - analyze_code_full
+            - install_trivy
           context: orb-publishing
           filters: *release-filters

--- a/src/commands/install_trivy.yml
+++ b/src/commands/install_trivy.yml
@@ -1,0 +1,18 @@
+description: >
+  Install Trivy (https://github.com/aquasecurity/trivy) all-in-one open source
+  security scanner, optionally selecting the specific version.
+
+parameters:
+  version:
+    type: string
+    default: ""
+    description: >
+      Choose the specific version of Trivy from https://github.com/aquasecurity/trivy/releases.
+      By default, the latest version is picked.
+
+steps:
+  - run:
+      name: Install Trivy
+      environment:
+        PARAM_STR_VERSION: <<parameters.version>>
+      command: <<include(scripts/install-trivy.sh)>>

--- a/src/scripts/install-trivy.sh
+++ b/src/scripts/install-trivy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+BASE_URL="https://raw.githubusercontent.com/aquasecurity/trivy"
+INSTALL_SCRIPT_URL="${BASE_URL}/main/contrib/install.sh" 
+TRIVY_DEST_DIR="${TRIVY_DEST_DIR:-/usr/local/bin}"
+
+function install_trivy () {
+  local script_args=(-b "${TRIVY_DEST_DIR}")
+
+  if [[ -n "${PARAM_STR_VERSION}" ]]; then
+    script_args+=("${PARAM_STR_VERSION}")
+  fi
+
+  set -x
+  curl -sfL --retry 1 "${INSTALL_SCRIPT_URL}" | sudo sh -s -- "${script_args[@]}"
+  set +x
+
+  echo "Installed trivy ${PARAM_STR_VERSION:-latest} at ${TRIVY_DEST_DIR}"
+}
+
+if ! command -v trivy >/dev/null 2>&1; then
+  echo "Failed to detect trivy, installing..."
+
+  install_trivy
+fi


### PR DESCRIPTION
The command to install Trivy open source security scanner. By default, the latest version is installed.
Useful for cases when an image with preinstalled Trviy is not suitable, e.g. when the machine executor is needed.