### PR TITLE
feat: add `install_syft` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -59,6 +59,18 @@ jobs:
               echo "Failed to install chosen trivy version"
               exit 1
             fi
+  install_syft:
+    executor: core/node
+    steps:
+      - security/install_syft:
+          version: v1.25.1
+      - run:
+          name: Validate installation
+          command: |
+            if ! syft --version | grep -q "1.25.1"; then
+              echo "Failed to install chosen syft version"
+              exit 1
+            fi
 
 workflows:
   test-deploy:
@@ -101,6 +113,8 @@ workflows:
           filters: *filters
       - install_trivy:
           filters: *filters
+      - install_syft:
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -118,5 +132,6 @@ workflows:
             - analyze_code_diff
             - analyze_code_full
             - install_trivy
+            - install_syft
           context: orb-publishing
           filters: *release-filters

--- a/src/commands/install_syft.yml
+++ b/src/commands/install_syft.yml
@@ -1,0 +1,18 @@
+description: >
+  Install Syft (https://github.com/anchore/syft) a CLI tool for generating
+  a Software Bill of Materials (SBOM) from container images and filesystems.
+
+parameters:
+  version:
+    type: string
+    default: ""
+    description: >
+      Choose the specific version of Syft from https://github.com/anchore/syft/releases.
+      By default, the latest version is picked.
+
+steps:
+  - run:
+      name: Install Syft
+      environment:
+        PARAM_STR_VERSION: <<parameters.version>>
+      command: <<include(scripts/install-syft.sh)>>

--- a/src/scripts/install-syft.sh
+++ b/src/scripts/install-syft.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+BASE_URL="https://raw.githubusercontent.com/anchore/syft"
+INSTALL_SCRIPT_URL="${BASE_URL}/main/install.sh" 
+SYFT_DEST_DIR="${SYFT_DEST_DIR:-/usr/local/bin}"
+
+function install_syft () {
+  local script_args=(-b "${SYFT_DEST_DIR}")
+
+  if [[ -n "${PARAM_STR_VERSION}" ]]; then
+    script_args+=("${PARAM_STR_VERSION}")
+  fi
+
+  set -x
+  curl -sfL --retry 1 "${INSTALL_SCRIPT_URL}" | sudo sh -s -- "${script_args[@]}"
+  set +x
+
+  echo "Installed syft ${PARAM_STR_VERSION:-latest} at ${SYFT_DEST_DIR}"
+}
+
+if ! command -v syft >/dev/null 2>&1; then
+  echo "Failed to detect syft, installing..."
+
+  install_syft
+fi


### PR DESCRIPTION
The command to install Syft a CLI tool for generating SBOM. By default, the latest version is installed.
Useful for cases when machine executor is needed in order to generate SBOM from image using Docker daemon as a source.