### PR TITLE
feat: add `install_grype` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -71,6 +71,18 @@ jobs:
               echo "Failed to install chosen syft version"
               exit 1
             fi
+  install_grype:
+    executor: core/node
+    steps:
+      - security/install_grype:
+          version: v0.92.1
+      - run:
+          name: Validate installation
+          command: |
+            if ! grype --version | grep -q "0.92.1"; then
+              echo "Failed to install chosen grype version"
+              exit 1
+            fi
 
 workflows:
   test-deploy:
@@ -115,6 +127,8 @@ workflows:
           filters: *filters
       - install_syft:
           filters: *filters
+      - install_grype:
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -133,5 +147,6 @@ workflows:
             - analyze_code_full
             - install_trivy
             - install_syft
+            - install_grype
           context: orb-publishing
           filters: *release-filters

--- a/src/commands/install_grype.yml
+++ b/src/commands/install_grype.yml
@@ -1,0 +1,18 @@
+description: >
+  Install Grype (https://github.com/anchore/grype) a vulnerability scanner for
+  container images and filesystems.
+
+parameters:
+  version:
+    type: string
+    default: ""
+    description: >
+      Choose the specific version of Grype from https://github.com/anchore/grype/releases.
+      By default, the latest version is picked.
+
+steps:
+  - run:
+      name: Install Grype
+      environment:
+        PARAM_STR_VERSION: <<parameters.version>>
+      command: <<include(scripts/install-grype.sh)>>

--- a/src/scripts/install-grype.sh
+++ b/src/scripts/install-grype.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+BASE_URL="https://raw.githubusercontent.com/anchore/grype"
+INSTALL_SCRIPT_URL="${BASE_URL}/main/install.sh" 
+GRYPE_DEST_DIR="${GRYPE_DEST_DIR:-/usr/local/bin}"
+
+function install_grype () {
+  local script_args=(-b "${GRYPE_DEST_DIR}")
+
+  if [[ -n "${PARAM_STR_VERSION}" ]]; then
+    script_args+=("${PARAM_STR_VERSION}")
+  fi
+
+  set -x
+  curl -sfL --retry 1 "${INSTALL_SCRIPT_URL}" | sudo sh -s -- "${script_args[@]}"
+  set +x
+
+  echo "Installed grype ${PARAM_STR_VERSION:-latest} at ${GRYPE_DEST_DIR}"
+}
+
+if ! command -v grype >/dev/null 2>&1; then
+  echo "Failed to detect grype, installing..."
+
+  install_grype
+fi


### PR DESCRIPTION
The command to install Grype a vulnerability scanner. By default, the latest version is installed.
Useful for cases when the source of an image being scanned is the Docker daemon, i.e. when using machine executor.