### PR TITLE
feat: add `generate_sbom` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@12.0
   core: studion/core@1.0.0
+  docker: circleci/docker@2.8.2
   security: {}
 
 filters: &filters
@@ -47,6 +48,29 @@ jobs:
       - checkout
       - security/scan_dockerfile:
           dockerfile_dir: ./sample
+  generate_sbom:
+    machine:
+      image: ubuntu-2204:current
+    steps:
+      - checkout
+      - docker/build:
+          image: security-sample
+          tag: v1
+          path: ./sample
+          docker-context: ./sample
+      - security/install_syft
+      - security/generate_sbom:
+          image: docker.io/security-sample:v1
+          out_path: /tmp/sample-sbom.json
+      - run:
+          name: Check SBOM output
+          command: |
+            if [ ! -f "/tmp/sample-sbom.json" ]; then
+              echo "SBOM output not found"
+              exit 1
+            fi
+
+            rm -f /tmp/sample-sbom.json
   install_trivy:
     executor: core/node
     steps:
@@ -95,6 +119,8 @@ workflows:
           filters: *filters
       - scan_dockerfile:
           filters: *filters
+      - generate_sbom:
+          filters: *filters
       - security/detect_secrets_dir:
           name: detect_secrets_dir
           filters: *filters
@@ -141,6 +167,7 @@ workflows:
             - scan_dependencies_prod_pnpm
             - scan_dependencies_command
             - scan_dockerfile
+            - generate_sbom
             - detect_secrets_dir
             - detect_secrets_git_base_revision
             - analyze_code_diff

--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -27,7 +27,9 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-l
 
 FROM install as build
 
-COPY ./src tsconfig.json tsconfig.tsbuildinfo ./
+# Explicitly preserve src dir hierarchy to resolve TS18003 during the build phase
+COPY src/ ./src/
+COPY tsconfig.json tsconfig.tsbuildinfo ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm run build
 

--- a/src/commands/generate_sbom.yml
+++ b/src/commands/generate_sbom.yml
@@ -1,0 +1,46 @@
+description: >
+  Generate Software Bill of Materials (SBOM) from Docker image.
+  All the work is done by Syft, for details see https://github.com/anchore/syft?tab=readme-ov-file#getting-started.
+  It is possible to provide additional configurable values by following this
+  guide https://github.com/anchore/syft/wiki/configuration#config-file.
+  However some options cannot be overridden, such as output and source
+  since they are passed as command line arguments and thus have the highest precedence.
+
+parameters:
+  image:
+    type: string
+    description: >
+      The Docker image to generate SBOM from. Support following schemes
+      (1) repo-name/image-name:tag (2) /path/to/image.tar. Bases on provided scheme
+      it will either use local Docker daemon or tarball archive from disk as a source.
+  format:
+    type: enum
+    enum:
+      - cyclonedx-json
+      - spdx-json
+      - github-json
+      - syft-json
+    default: cyclonedx-json
+    description: >
+      Choose the output format of generated SBOM. By default a JSON report
+      conforming to the CycloneDX specification.
+  out_path:
+    type: string
+    default: /tmp/sbom.json
+    description: Path to the file to write the SBOM report to.
+  exclude:
+    type: string
+    default: ""
+    description: >
+      Space delimited list of GLOB expressions specifying files and paths to
+      exclude from the source.
+
+steps:
+  - run:
+      name: Generate SBOM
+      environment:
+        PARAM_STR_IMAGE: <<parameters.image>>
+        PARAM_ENUM_FORMAT: <<parameters.format>>
+        PARAM_STR_OUT_PATH: <<parameters.out_path>>
+        PARAM_STR_EXCLUDE: <<parameters.exclude>>
+      command: <<include(scripts/generate-sbom.sh)>>

--- a/src/examples/image_sbom.yml
+++ b/src/examples/image_sbom.yml
@@ -1,0 +1,27 @@
+description: |
+  The "generate_sbom" command generates SBOM from the Docker image.
+  By default, the Docker daemon is used as a source. This can be changed
+  to use the Docker archive from the disk by providing the path to the tarball
+  file as the "image".
+  There is an option to customize output path of the report, exclude
+  directories or files from the scan with glob expressions or use
+  different output format.
+
+usage:
+  version: 2.1
+  orbs:
+    security: studion/security@x.y.z
+  jobs:
+    sbom:
+      executor: security/node
+      steps:
+        - checkout
+        - security/generate_sbom:
+            image: studiondev/node-security:lts
+            format: github-json
+            out_path: /tmp/reports/lts-sbom.json
+            exclude: /etc /home/**/*.json
+  workflows:
+    compliance:
+      jobs:
+        - sbom

--- a/src/scripts/generate-sbom.sh
+++ b/src/scripts/generate-sbom.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [[ -z "${PARAM_STR_IMAGE}" ]]; then
+  echo "Specify image and retry."
+
+  exit 1
+fi
+
+IMAGE_SOURCE="docker"
+
+if [[ "${PARAM_STR_IMAGE}" == *.tar ]]; then
+  IMAGE_SOURCE="docker-archive"
+fi
+
+SBOM_ARGS=("${IMAGE_SOURCE}:${PARAM_STR_IMAGE}")
+SBOM_ARGS+=("-o" "${PARAM_ENUM_FORMAT}=${PARAM_STR_OUT_PATH}")
+
+if [[ -n "${PARAM_STR_EXCLUDE}" ]]; then
+  set -f # Disable glob expansion
+  for exclude_glob in ${PARAM_STR_EXCLUDE}; do
+    SBOM_ARGS+=("--exclude=$exclude_glob")
+  done
+  set +f
+fi
+
+set -x
+syft "${SBOM_ARGS[@]}"
+set +x


### PR DESCRIPTION
The command generates SBOM from the Docker image.
Under the hood uses Syft to accomplish this.
Sources image from Docker daemon or tarball file from disk.