### PR TITLE
feat: add "assess_image" command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -48,17 +48,19 @@ jobs:
       - checkout
       - security/scan_dockerfile:
           dockerfile_dir: ./sample
-  generate_sbom:
+  generate_sbom_and_assess_image:
     machine:
       image: ubuntu-2204:current
     steps:
       - checkout
+      - security/install_grype
+      - security/install_syft
+      - security/install_trivy
       - docker/build:
           image: security-sample
           tag: v1
           path: ./sample
           docker-context: ./sample
-      - security/install_syft
       - security/generate_sbom:
           image: docker.io/security-sample:v1
           out_path: /tmp/sample-sbom.json
@@ -69,8 +71,22 @@ jobs:
               echo "SBOM output not found"
               exit 1
             fi
-
+      - security/assess_image:
+          image: docker.io/security-sample:v1
+          severity: critical
+          report_path: /tmp/sample-vuln-report.json
+      - run:
+          name: Check vulnerability report
+          command: |
+            if [ ! -f "/tmp/sample-vuln-report.json" ]; then
+              echo "Vulnerability report not found"
+              exit 1
+            fi
+      - run:
+          name: Cleanup
+          command: |
             rm -f /tmp/sample-sbom.json
+            rm -f /tmp/sample-vuln-report.json
   install_trivy:
     executor: core/node
     steps:
@@ -119,7 +135,7 @@ workflows:
           filters: *filters
       - scan_dockerfile:
           filters: *filters
-      - generate_sbom:
+      - generate_sbom_and_assess_image:
           filters: *filters
       - security/detect_secrets_dir:
           name: detect_secrets_dir
@@ -167,7 +183,7 @@ workflows:
             - scan_dependencies_prod_pnpm
             - scan_dependencies_command
             - scan_dockerfile
-            - generate_sbom
+            - generate_sbom_and_assess_image
             - detect_secrets_dir
             - detect_secrets_git_base_revision
             - analyze_code_diff

--- a/src/commands/assess_image.yml
+++ b/src/commands/assess_image.yml
@@ -1,0 +1,73 @@
+description: >
+  Scan Docker images for vulnerabilities and secrets.
+  Vulnerability scan is performed by Grype (https://github.com/anchore/grype)
+  while scanning for secrets is executed by Trivy (https://github.com/aquasecurity/trivy).
+  It is possible to provide additional configurable options by following the Grype
+  (https://github.com/anchore/grype?tab=readme-ov-file#configuration) and Trivy
+  (https://trivy.dev/latest/docs/configuration/) guides, respectively.
+  However, some options cannot be overridden, such as source and format,
+  since they are passed as command line arguments and thus have the highest precedence.
+
+parameters:
+  image:
+    type: string
+    description: >
+      The Docker image to scan. Support following schemes
+      (1) 'repo-name/image-name:tag' (2) '/path/to/image.tar'. Bases on provided scheme
+      it will either use local Docker daemon or tarball archive from disk as a source.
+  scanners:
+    type: string
+    default: vuln secret
+    description: >
+      Space delimited list of scans to run against the image. By default, runs all
+      available scans. Following is available (1) 'vuln' - vulnerability scan
+      (2) 'secret' - secrets scan of the image and its configuration.
+  severity:
+    type: enum
+    enum:
+      - low
+      - medium
+      - high
+      - critical
+    default: high
+    description: >
+      Choose a severity level to fail on with the error code. By default,
+      when severity level of 'high' or greater is detected the command will
+      fail with exit code 2.
+  exclude:
+    type: string
+    default: ""
+    description: >
+      Space delimited list of GLOB expressions specifying files and paths to
+      exclude from the vulnerability scan. The secrets scan is not affected by this.
+  ignore_fix_status:
+    type: string
+    default: ""
+    description: >
+      Comma delimited list of matches to ignore based on the vulnerability fix status.
+      Available options - 'fixed', 'not-fixed', 'wont-fix', 'unknown'.
+  report_format:
+    type: enum
+    enum:
+      - cyclonedx-json
+      - json
+    default: cyclonedx-json
+    description: >
+      Choose the format of the vulnerability report. By default, a JSON format
+      conforming ot the CycloneDX specification.
+  report_path:
+    type: string
+    default: /tmp/vuln-report.json
+    description: Path to the file to write the vulnerability report to.
+
+steps:
+  - run:
+      name: Assess image "<<parameters.image>>"
+      environment:
+        PARAM_STR_IMAGE: <<parameters.image>>
+        PARAM_STR_SCANNERS: <<parameters.scanners>>
+        PARAM_ENUM_SEVERITY: <<parameters.severity>>
+        PARAM_STR_IGNORE_FIX_STATUS: <<parameters.ignore_fix_status>>
+        PARAM_ENUM_REPORT_FORMAT: <<parameters.report_format>>
+        PARAM_STR_REPORT_PATH: <<parameters.report_path>>
+      command: <<include(scripts/assess-image.sh)>>

--- a/src/examples/image_scan.yml
+++ b/src/examples/image_scan.yml
@@ -1,0 +1,28 @@
+description: |
+  By default, the "assess_image" command scans images for high and critical
+  severity vulnerabilities and secrets. It uses the Docker daemon as the
+  image source, or alternatively an image tarball file from disk if provided.
+  There is an option to choose scanners, set severity levels, ignore findings
+  based on fix status, exclude directories or files using the glob expressions,
+  select different report format, and customize report path.
+
+usage:
+  version: 2.1
+  orbs:
+    security: studion/security@x.y.z
+  jobs:
+    vuln-and-secrets:
+      machine:
+        image: ubuntu-2204:current
+      steps:
+        - checkout
+        - security/assess_image:
+            image: studiondev/node-security:lts
+            severity: medium
+            ignore-fix-status: not-fixed,wont-fix
+            exclude: /usr /var/**/*.log
+            report-path: /tmp/reports/lts-vuln.json
+  workflows:
+    scan-image:
+      jobs:
+        - vuln-and-secrets

--- a/src/scripts/assess-image.sh
+++ b/src/scripts/assess-image.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+if [[ -z "${PARAM_STR_IMAGE}" ]]; then
+  echo "Specify image and retry."
+
+  exit 1
+fi
+
+
+function scan_secrets () {
+  local args=(image "--scanners=secret" "--image-config-scanners=secret")
+
+  if [[ "${PARAM_STR_IMAGE}" == *.tar ]]; then
+    args+=(--input)
+  fi
+
+  args+=("${PARAM_STR_IMAGE}")
+
+  set -x
+  trivy "${args[@]}"
+  set +x
+}
+
+function scan_vuln () {
+  local args=()
+
+  if [[ "${PARAM_STR_IMAGE}" == *.tar ]]; then
+    args+=("docker-archive:${PARAM_STR_IMAGE}")
+  else
+    args+=("docker:${PARAM_STR_IMAGE}")
+  fi
+  
+  if [[ -n "${PARAM_STR_IGNORE_FIX_STATUS}" ]]; then
+    args+=("--ignore-states=${PARAM_STR_IGNORE_FIX_STATUS}")
+  fi
+
+  if [[ -n "${PARAM_STR_EXCLUDE}" ]]; then
+    set -f # Disable glob expansion
+    for exclude_glob in ${PARAM_STR_EXCLUDE}; do
+      args+=("--exclude=$exclude_glob")
+    done
+    set +f
+  fi
+
+  args+=(--by-cve "--fail-on=${PARAM_ENUM_SEVERITY}")
+  args+=("--output=${PARAM_ENUM_REPORT_FORMAT}")
+  args+=("--file=${PARAM_STR_REPORT_PATH}")
+
+  set -x
+  grype "${args[@]}"
+  set +x
+}
+
+set -f # Disable glob expansion
+for scanner in ${PARAM_STR_SCANNERS}; do
+  if [[ $scanner == "vuln" ]]; then
+    scan_vuln
+  elif [[ $scanner == "secret" ]]; then
+    scan_secrets
+  else
+    echo "Unknow image scanner: $scanner"
+    exit 1
+  fi
+done
+set +f


### PR DESCRIPTION
The command scans Docker image for vulnerabilities and secrets. Under the hood uses Grype for the vulnerability scan and Trivy for the secret scan.
Sources image from the Docker daemon of the tarball file from disk.