### PR TITLE
ci: update `studion/core` to `v3.0.0`

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@12.0
-  core: studion/core@1.0.0
+  core: studion/core@3.0.0
   docker: circleci/docker@2.8.2
   security: {}
 


### PR DESCRIPTION
The core orb is regularly updated as a dependency. However, that does not affect orbs "test-deploy" config. This change address this neglected part.