### PR TITLE
feat: add `install_semgrep` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -123,6 +123,19 @@ jobs:
               echo "Failed to install chosen grype version"
               exit 1
             fi
+  install_semgrep:
+    machine:
+      image: ubuntu-2404:current
+    steps:
+      - security/install_semgrep:
+          version: v1.121.0
+      - run:
+          name: Validate installation
+          command: |
+            if ! semgrep --version | grep -q "1.121.0"; then
+              echo "Failed to install chosen semgrep version"
+              exit 1
+            fi
 
 workflows:
   test-deploy:
@@ -171,6 +184,8 @@ workflows:
           filters: *filters
       - install_grype:
           filters: *filters
+      - install_semgrep:
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -191,5 +206,6 @@ workflows:
             - install_trivy
             - install_syft
             - install_grype
+            - install_semgrep
           context: orb-publishing
           filters: *release-filters

--- a/src/commands/install_semgrep.yml
+++ b/src/commands/install_semgrep.yml
@@ -1,0 +1,20 @@
+description: >
+  Install Semgrep (https://github.com/semgrep/semgrep) a fast open-source static
+  analysis tool.
+  Requires the runtime environment with Python 3 and Pip. Installs Semgrep in
+  the user-specific location, not system-wide.
+
+parameters:
+  version:
+    type: string
+    default: ""
+    description: >
+      Choose the specific version of Semgrep from https://github.com/semgrep/semgrep/releases.
+      By default, the latest version is picked.
+
+steps:
+  - run:
+      name: Install Semgrep
+      environment:
+        PARAM_STR_VERSION: <<parameters.version>>
+      command: <<include(scripts/install-semgrep.sh)>>

--- a/src/scripts/install-semgrep.sh
+++ b/src/scripts/install-semgrep.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+function install_semgrep() {
+  local semgrep_arg
+  local install_path
+
+  [[ -n "${PARAM_STR_VERSION}" ]] && semgrep_arg="semgrep==${PARAM_STR_VERSION#v}" || semgrep_arg="semgrep"
+
+  set -x
+  # Installing without the '--user' flag results in the command not found error
+  # due to issue how pip installed packages are added to the PATH in CI environments.
+  # Adding the '--user' flag, (alongside the '--no-warn-script-location' to suppress
+  # the location warnings) installs the package in a user specific directory which
+  # is afterwards added to the PATH.
+  python3 -m pip install --no-warn-script-location --user "${semgrep_arg}"
+  set +x
+
+  install_path="$(python3 -m site --user-base)/bin"
+
+  echo "Adding Semgrep installation path (${install_path}) to the PATH"
+  echo "export PATH=${install_path}:${PATH}" >>"${BASH_ENV}"
+}
+
+if ! command -v python3 >/dev/null 2>&1 || ! command -v pip3 >/dev/null 2>&1; then
+  echo "Python 3 and Pip are required"
+  exit 1
+fi
+
+if ! command -v semgrep >/dev/null 2>&1; then
+  echo "Failed to detect Semgrep, installing..."
+
+  install_semgrep
+fi


### PR DESCRIPTION
The command to install Semgrep static analysis tool. By default, the latest version is installed.
Useful for cases when using Docker daemon and machine executor.