### PR TITLE
feat: add `install_gitleaks` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -136,6 +136,18 @@ jobs:
               echo "Failed to install chosen semgrep version"
               exit 1
             fi
+  install_gitleaks:
+    executor: core/node
+    steps:
+      - security/install_gitleaks:
+          version: v8.25.1
+      - run:
+          name: Validate installation
+          command: |
+            if ! gitleaks --version | grep -q "8.25.1"; then
+              echo "Failed to install chosen gitleaks version"
+              exit 1
+            fi
 
 workflows:
   test-deploy:
@@ -186,6 +198,8 @@ workflows:
           filters: *filters
       - install_semgrep:
           filters: *filters
+      - install_gitleaks:
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -207,5 +221,6 @@ workflows:
             - install_syft
             - install_grype
             - install_semgrep
+            - install_gitleaks
           context: orb-publishing
           filters: *release-filters

--- a/src/commands/install_gitleaks.yml
+++ b/src/commands/install_gitleaks.yml
@@ -1,0 +1,17 @@
+description: >
+  Install Gitleaks (https://github.com/gitleaks/gitleaks) a tool for detecting secrets.
+
+parameters:
+  version:
+    type: string
+    default: ""
+    description: >
+      Choose the specific version of Gitleaks from https://github.com/anchore/grype/releases.
+      By default, the latest version is picked.
+
+steps:
+  - run:
+      name: Install Gitleaks
+      environment:
+        PARAM_STR_VERSION: <<parameters.version>>
+      command: <<include(scripts/install-gitleaks.sh)>>

--- a/src/scripts/install-gitleaks.sh
+++ b/src/scripts/install-gitleaks.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+OS=$(uname | sed 's/Darwin/darwin/;s/Linux/linux/')
+ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
+GL_DEST_DIR="${GL_DEST_DIR:-/usr/local/bin}"
+BASE_URL="https://github.com/gitleaks/gitleaks"
+
+function get_release_url() {
+  local release_url
+  local version
+
+  if [[ -n "${PARAM_STR_VERSION}" ]]; then
+    version="${PARAM_STR_VERSION}"
+  else
+    version=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name)
+  fi
+
+  release_url="${BASE_URL}/releases/download/${version}/gitleaks_${version#v}_${OS}_${ARCH}.tar.gz"
+
+  echo "${release_url}"
+}
+
+function install_gitleaks() {
+  local work_dir
+  local temp_dir
+  local release_url
+
+  work_dir=$(pwd)
+  temp_dir=$(mktemp -d 'tmp.XXXXX')
+  release_url=$(get_release_url)
+
+  cd "${temp_dir}" || exit 1
+
+  set -x
+  curl -sfL --retry 1 "${release_url}" | tar zx
+  sudo install "gitleaks" "${GL_DEST_DIR}"
+  set +x
+
+  echo "Installed $(gitleaks --version) at $(command -v gitleaks)"
+
+  cd "${work_dir}" || exit 1
+  rm -rf "${temp_dir}"
+}
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "Failed to detect gitleaks, installing..."
+
+  install_gitleaks
+fi


### PR DESCRIPTION
The command to install Gitleaks secrets detection tool. By default, the latest version is installed.
Useful for cases when using the machine executor.