### PR TITLE
feat: perform env subst on image for the `generate_sbom` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -61,8 +61,11 @@ jobs:
           tag: v1
           path: ./sample
           docker-context: ./sample
+      - run:
+          name: Export image as env
+          command: echo "export IMAGE_TO_USE=docker.io/security-sample:v1" >> "${BASH_ENV}"
       - security/generate_sbom:
-          image: docker.io/security-sample:v1
+          image: ${IMAGE_TO_USE}
           out_path: /tmp/sample-sbom.json
       - run:
           name: Check SBOM output

--- a/src/commands/generate_sbom.yml
+++ b/src/commands/generate_sbom.yml
@@ -13,6 +13,7 @@ parameters:
       The Docker image to generate SBOM from. Support following schemes
       (1) repo-name/image-name:tag (2) /path/to/image.tar. Bases on provided scheme
       it will either use local Docker daemon or tarball archive from disk as a source.
+      Performs environment variable substitution before using the value of this parameter.
   format:
     type: enum
     enum:

--- a/src/examples/image_sbom.yml
+++ b/src/examples/image_sbom.yml
@@ -14,10 +14,12 @@ usage:
   jobs:
     sbom:
       executor: security/node
+      environment:
+        TARGET_IMAGE: studiondev/node-security:lts
       steps:
         - checkout
         - security/generate_sbom:
-            image: studiondev/node-security:lts
+            image: ${TARGET_IMAGE}
             format: github-json
             out_path: /tmp/reports/lts-sbom.json
             exclude: /etc /home/**/*.json

--- a/src/scripts/generate-sbom.sh
+++ b/src/scripts/generate-sbom.sh
@@ -6,6 +6,8 @@ if [[ -z "${PARAM_STR_IMAGE}" ]]; then
   exit 1
 fi
 
+PARAM_STR_IMAGE=$(circleci env subst "${PARAM_STR_IMAGE}")
+
 IMAGE_SOURCE="docker"
 
 if [[ "${PARAM_STR_IMAGE}" == *.tar ]]; then


### PR DESCRIPTION
Allow providing the environment variable as the value of the `image` parameter for the `generate_sbom` command. Useful for cases when image name is not known upfront.