### PR TITLE
feat: perform env subst on image for the `assess_image` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -75,7 +75,7 @@ jobs:
               exit 1
             fi
       - security/assess_image:
-          image: docker.io/security-sample:v1
+          image: ${IMAGE_TO_USE}
           severity: critical
           report_path: /tmp/sample-vuln-report.json
       - run:

--- a/src/commands/assess_image.yml
+++ b/src/commands/assess_image.yml
@@ -15,6 +15,7 @@ parameters:
       The Docker image to scan. Support following schemes
       (1) 'repo-name/image-name:tag' (2) '/path/to/image.tar'. Bases on provided scheme
       it will either use local Docker daemon or tarball archive from disk as a source.
+      Performs environment variable substitution before using the value of this parameter.
   scanners:
     type: string
     default: vuln secret

--- a/src/examples/image_scan.yml
+++ b/src/examples/image_scan.yml
@@ -14,10 +14,12 @@ usage:
     vuln-and-secrets:
       machine:
         image: ubuntu-2204:current
+      environment:
+        TARGET_IMAGE: studiondev/node-security:lts
       steps:
         - checkout
         - security/assess_image:
-            image: studiondev/node-security:lts
+            image: ${TARGET_IMAGE}
             severity: medium
             ignore-fix-status: not-fixed,wont-fix
             exclude: /usr /var/**/*.log

--- a/src/scripts/assess-image.sh
+++ b/src/scripts/assess-image.sh
@@ -6,6 +6,7 @@ if [[ -z "${PARAM_STR_IMAGE}" ]]; then
   exit 1
 fi
 
+PARAM_STR_IMAGE=$(circleci env subst "${PARAM_STR_IMAGE}")
 
 function scan_secrets () {
   local args=(image "--scanners=secret" "--image-config-scanners=secret")


### PR DESCRIPTION
Support providing the environment variable as the value of the `image` parameter for the `assess_image` command.
Useful for cases when image name is not known upfront.