### PR TITLE
feat: standardize output paths of the commands

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -66,22 +66,20 @@ jobs:
           command: echo "export IMAGE_TO_USE=docker.io/security-sample:v1" >> "${BASH_ENV}"
       - security/generate_sbom:
           image: ${IMAGE_TO_USE}
-          out_path: /tmp/sample-sbom.json
       - run:
           name: Check SBOM output
           command: |
-            if [ ! -f "/tmp/sample-sbom.json" ]; then
+            if [ ! -f "/tmp/security-orb/output/sbom.json" ]; then
               echo "SBOM output not found"
               exit 1
             fi
       - security/assess_image:
           image: ${IMAGE_TO_USE}
           severity: critical
-          report_path: /tmp/sample-vuln-report.json
       - run:
           name: Check vulnerability report
           command: |
-            if [ ! -f "/tmp/sample-vuln-report.json" ]; then
+            if [ ! -f "/tmp/security-orb/output/image-findings.json" ]; then
               echo "Vulnerability report not found"
               exit 1
             fi

--- a/src/commands/assess_image.yml
+++ b/src/commands/assess_image.yml
@@ -58,7 +58,7 @@ parameters:
       conforming ot the CycloneDX specification.
   report_path:
     type: string
-    default: /tmp/vuln-report.json
+    default: /tmp/security-orb/output/image-findings.json
     description: Path to the file to write the vulnerability report to.
 
 steps:

--- a/src/commands/generate_sbom.yml
+++ b/src/commands/generate_sbom.yml
@@ -27,7 +27,7 @@ parameters:
       conforming to the CycloneDX specification.
   out_path:
     type: string
-    default: /tmp/sbom.json
+    default: /tmp/security-orb/output/sbom.json
     description: Path to the file to write the SBOM report to.
   exclude:
     type: string


### PR DESCRIPTION
The outputs of commands are now saved at the standardized path `/tmp/security-orb/output`.
This is a breaking change and affects following commands:
- `assess_image`
- `generate_sbom`