### PR TITLE
refactor: use array for passing arguments in scripts

### DIFF
--- a/src/scripts/analyze-code.sh
+++ b/src/scripts/analyze-code.sh
@@ -5,22 +5,15 @@
 # is only observed in CI environment.
 # When the `experimental` flag is set, saving the output to the
 # file will not work and is just silently ignored.
-ARGS="--experimental --error --strict --metrics off"
+ARGS=(--experimental --error --strict --metrics=off)
 BASELINE_COMMIT=""
 
-function join() {
-  local separator="$1"
-  shift
-  local first="$1"
-  shift
-  printf "%s" "${first}" "${@/#/$separator}"
-}
-
-IFS=' ' read -ra RULE_ARRAY <<<"${PARAM_STR_RULES}"
-ARGS="${ARGS} --config $(join ' --config ' "${RULE_ARRAY[@]}")"
+for rule in ${PARAM_STR_RULES}; do
+  ARGS+=("--config=$rule")
+done
 
 if [ "${PARAM_BOOL_VERBOSE}" -eq 1 ]; then
-  ARGS="${ARGS} --verbose"
+  ARGS+=(--verbose)
 fi
 
 if [ "${PARAM_BOOL_FULL_SCAN}" -eq 0 ]; then
@@ -43,9 +36,9 @@ else
 fi
 
 if [[ -n ${BASELINE_COMMIT} ]]; then
-  ARGS="${ARGS} --baseline-commit ${BASELINE_COMMIT}"
+  ARGS+=("--baseline-commit=${BASELINE_COMMIT}")
 fi
 
 set -x
-eval semgrep "${ARGS}"
+semgrep "${ARGS[@]}"
 set +x

--- a/src/scripts/detect-secrets-dir.sh
+++ b/src/scripts/detect-secrets-dir.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
+ARGS=()
+
+read -ra ARGS <<<"${GITLEAKS_ARGS}"
+
 echo "Starting the directory scan at path '${PWD}'"
 
 set -x
-eval \
-  gitleaks \
-  dir \
-  "${GITLEAKS_ARGS}" \
-  .
+gitleaks dir "${ARGS[@]}" .
 set +x

--- a/src/scripts/detect-secrets-git.sh
+++ b/src/scripts/detect-secrets-git.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+ARGS=()
 LOG_OPTS=""
+
+read -ra ARGS <<<"${GITLEAKS_ARGS}"
 
 echo "Using '${GIT_BASE_BRANCH}' as the base branch"
 echo "Using '${GIT_CURRENT_BRANCH}' as the current branch"
@@ -29,11 +32,8 @@ else
   LOG_OPTS="${GIT_BASE_BRANCH}..${GIT_CURRENT_BRANCH}"
 fi
 
+ARGS+=("--log-opts=${LOG_OPTS}")
+
 set -x
-eval \
-  gitleaks \
-  git \
-  "${GITLEAKS_ARGS}" \
-  --log-opts="${LOG_OPTS}" \
-  .
+gitleaks git "${ARGS[@]}" .
 set +x

--- a/src/scripts/export-gitleaks-args.sh
+++ b/src/scripts/export-gitleaks-args.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-ARGS="--log-level=debug --verbose --redact --exit-code=2"
+ARGS=(--log-level=debug --verbose --redact --exit-code=2)
 
 if [[ -n "${PARAM_STR_CONFIG_FILE}" ]]; then
-  ARGS="${ARGS} --config=${PARAM_STR_CONFIG_FILE}"
+  ARGS+=("--config=${PARAM_STR_CONFIG_FILE}")
 fi
 
 if [[ -n "${PARAM_STR_BASELINE_REPORT}" ]]; then
-  ARGS="${ARGS} --baseline-path=${PARAM_STR_BASELINE_REPORT}"
+  ARGS+=("--baseline-path=${PARAM_STR_BASELINE_REPORT}")
 fi
 
-echo "export GITLEAKS_ARGS='${ARGS}'" >>"${BASH_ENV}"
+echo "export GITLEAKS_ARGS='${ARGS[*]}'" >>"${BASH_ENV}"


### PR DESCRIPTION
Use array and array expansion for passing arguments to commands inside the `sh` files. Some newer scripts already started with this practice and now it is applied across the older ones as well. This avoids using `eval` since it is not necessary making code safe, predictable, cleaner and maintainable.
Affected commands and jobs:
- `analyze_code`
- `analyze_code_diff`
- `analyze_code_full`
- `detect_secrets`
- `detect_secrets_dir`
- `detect_secrets_git`