### PR TITLE
chore: update machine images to `ubuntu-2404`

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           dockerfile_dir: ./sample
   generate_sbom_and_assess_image:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     steps:
       - checkout
       - security/install_grype

--- a/src/examples/image_scan.yml
+++ b/src/examples/image_scan.yml
@@ -13,7 +13,7 @@ usage:
   jobs:
     vuln-and-secrets:
       machine:
-        image: ubuntu-2204:current
+        image: ubuntu-2404:current
       environment:
         TARGET_IMAGE: studiondev/node-security:lts
       steps:


### PR DESCRIPTION
All machine executors are now using the latest LTS version of Ubuntu, `24.04`.