### PR TITLE
feat: store SBOM as artifact

### DIFF
--- a/src/commands/generate_sbom.yml
+++ b/src/commands/generate_sbom.yml
@@ -45,3 +45,6 @@ steps:
         PARAM_STR_OUT_PATH: <<parameters.out_path>>
         PARAM_STR_EXCLUDE: <<parameters.exclude>>
       command: <<include(scripts/generate-sbom.sh)>>
+  - store_artifacts:
+      path: <<parameters.out_path>>
+      destination: security-orb/sbom


### PR DESCRIPTION
Store output of the `generate_sbom` command
as the artifact using the `store_artifacts` step.