### PR TITLE
feat: add option to provide root for the `analyze_code` command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -188,6 +188,7 @@ workflows:
           filters: *filters
       - security/analyze_code_full:
           name: analyze_code_full
+          root_dir: ./sample
           rules: p/cwe-top-25
           filters: *filters
       - scan_dependencies_prod_npm:

--- a/src/commands/analyze_code.yml
+++ b/src/commands/analyze_code.yml
@@ -3,6 +3,12 @@ description: >
   command to do the analysis. For details on usage see https://semgrep.dev/docs/cli-reference.
 
 parameters:
+  root_dir:
+    type: string
+    default: "."
+    description: >
+      The root of the codebase to analyze. Defaults to . (working directory).
+      Complements the full scan mode, by enabling partial scan of the codebase.
   full_scan:
     type: boolean
     default: false
@@ -21,7 +27,7 @@ parameters:
       file, or Semgrep registry entry name.
   base_branch:
     type: string
-    default: ''
+    default: ""
     description: >
       The name of the base branch for this scan. Commonly a long-lived branch, e.g. "main" or "master".
 
@@ -36,6 +42,7 @@ steps:
             command: <<include(scripts/export-git-branches.sh)>>
   - run:
       name: Analyze code <<#parameters.full_scan>>full<</parameters.full_scan>><<^parameters.full_scan>>diff<</parameters.full_scan>>
+      working_directory: <<parameters.root_dir>>
       environment:
         PARAM_BOOL_FULL_SCAN: <<parameters.full_scan>>
         PARAM_BOOL_VERBOSE: <<parameters.verbose>>

--- a/src/jobs/analyze_code_full.yml
+++ b/src/jobs/analyze_code_full.yml
@@ -4,6 +4,11 @@ description: >
 executor: node
 
 parameters:
+  root_dir:
+    type: string
+    default: "."
+    description: >
+      The root of the codebase to analyze. Defaults to . (working directory).
   verbose:
     type: boolean
     default: false
@@ -19,5 +24,6 @@ steps:
   - checkout
   - analyze_code:
       full_scan: true
+      root_dir: <<parameters.root_dir>>
       verbose: <<parameters.verbose>>
       rules: <<parameters.rules>>

--- a/src/scripts/analyze-code.sh
+++ b/src/scripts/analyze-code.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "Starting codebase analysis at root directory: ${PWD}"
+
 # The `experimental` flag is needed for Semgrep to work, otherwise
 # for unknown reason it will fail with exit code 2. This behavior
 # is only observed in CI environment.


### PR DESCRIPTION
The `analyze_code` command now supports providing the root of the scan through the `root_dir` parameter. This enables partial scans of the codebase in the full mode.
Corresponding `analyze_code_full` jobs also enables the same functionality.