### PR TITLE
fix: use full checkout for detect secrets jobs

### DIFF
--- a/src/jobs/detect_secrets_dir.yml
+++ b/src/jobs/detect_secrets_dir.yml
@@ -19,7 +19,8 @@ parameters:
     description: The path to the baseline report, i.e. issues that can be ignored.
 
 steps:
-  - checkout
+  - checkout:
+      method: full
   - detect_secrets:
       source: <<parameters.source>>
       mode: dir

--- a/src/jobs/detect_secrets_git.yml
+++ b/src/jobs/detect_secrets_git.yml
@@ -26,7 +26,8 @@ parameters:
       "<<pipeline.git.base_revision>>" pipeline parameter.
 
 steps:
-  - checkout
+  - checkout:
+      method: full
   - detect_secrets:
       mode: git
       config: <<parameters.config>>


### PR DESCRIPTION
CircleCI is changing default checkout method from `full` to `blobless`, which is incompatible with Gitleaks.
Explicitly set checkout method to `full` for detect secrets jobs to continue proper operating.